### PR TITLE
fix(scheduler): consider 4xx status code because server works

### DIFF
--- a/scheduler/src/ping.py
+++ b/scheduler/src/ping.py
@@ -14,7 +14,7 @@ def check_availability(domain: str) -> bool:
     logger.info("Checking domain availability...")
     try:
         response = requests.head(f"http://{domain}", timeout=5)
-        return response.status_code >= 200 and response.status_code < 400
+        return response.status_code >= 200 and response.status_code < 500
     except (exceptions.ConnectionError, exceptions.Timeout):
         return False
 

--- a/scheduler/tests/test_ping.py
+++ b/scheduler/tests/test_ping.py
@@ -78,7 +78,8 @@ def test_ping_domains_with_exception(
     [
         (200, True),
         (302, True),
-        (404, False),
+        (403, True),
+        (404, True),
         (500, False),
         (503, False),
     ],


### PR DESCRIPTION
## Descrição

Este pull request tem como objetivo de aplicar uma correção no que considera um domínio com servidor disponível. Respostas do tipo 4xx podem ser consideradas disponíveis, porque um servidor respondeu o cliente, mesmo quando o recurso solicitado não existe (404) ou não tem autorização para solicitar (403).

### Alterações realizadas

- **scheduler/src/ping.py**: Aumenta o _range_ das classes de status code, o que forem menores a 5xx
- **scheduler/tests/test_ping.py**: Refatoração do teste para cobrir esse caso

### Contexto adicional

- Isso foi necessário porque tem portais do governo que respondem com classes de status antes considerado indisponível, mas que ainda assim buscam redirecionar para outro domínio, como é o caso do [amapa.gov.br](http://amapa.gov.br)

### Checklist

- [x] Os testes foram executados e passaram com sucesso
- [ ] A documentação foi atualizada, se necessário
- [x] O código segue as diretrizes de estilo do projeto
- [x] Foram adicionados testes automatizados para as novas funcionalidades ou correções
