### PR TITLE
Define options to refresh database connections via keep alive and pool

### DIFF
--- a/api/src/core/database.py
+++ b/api/src/core/database.py
@@ -9,6 +9,10 @@ from src.core.config import settings
 engine = create_engine(
     settings.DATABASE_URL if not settings.DEBUG else settings.TEST_DATABASE_URL,
     echo=settings.DEBUG,
+    pool_pre_ping=True,
+    pool_size=5,
+    pool_recycle=3600,
+    pool_timeout=30,
 )
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 

--- a/lib/database.py
+++ b/lib/database.py
@@ -12,7 +12,7 @@ from psycopg2.extras import execute_batch
 def create_connection() -> connection:
     database_url = os.getenv("DATABASE_URL")
     dsn = parse_dsn(database_url)
-    return psycopg2.connect(**dsn)  # noqa
+    return psycopg2.connect(keepalives=1, keepalives_idle=30, keepalives_interval=10, keepalives_count=5, **dsn)  # noqa
 
 
 def create_cursor(conn: connection) -> cursor:


### PR DESCRIPTION
## Descrição

Este pull request tem como objetivo buscar meios de resolver o erro abaixo que periodicamente acontece:

```
(psycopg2.OperationalError) server closed the connection unexpectedly
	This probably means the server terminated abnormally
	before or while processing the request.
```

Parte disso pode ser característica do ambiente do [fly.io](https://fly.io), em que depois de um tempo o banco entra no "modo sleep" além da aplicação backend, perdendo a conexão e não fazendo um _double check_ na sessão.

### Alterações realizadas

- **api/src/core/database.py**: Define parâmetros de pool de conexão
- **lib/database.py**: Define parâmetros de `keepalive`

### Contexto adicional

- [Mencionar qualquer contexto adicional relevante para entender as alterações]

### Issues relacionadas

- Issue #37 

### Checklist

- [ ] Os testes foram executados e passaram com sucesso
- [ ] A documentação foi atualizada, se necessário
- [ ] O código segue as diretrizes de estilo do projeto
- [ ] Foram adicionados testes automatizados para as novas funcionalidades ou correções
